### PR TITLE
Fix signals in constraint tests

### DIFF
--- a/tests/randomize-constraints/constraint_dist.sv
+++ b/tests/randomize-constraints/constraint_dist.sv
@@ -18,16 +18,20 @@ class Cls;
 endclass
 
 module top (
+    input clk,
     output logic [7:0] o
 );
     Cls obj;
     initial begin
        int success;
-       for (int i = 0; i < 5; i++) begin
+       for (int i = 0; i < 50; i++) begin
          obj= new;
          success = obj.randomize();
          $display("val = %0b", obj.val);
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 
     assign o = obj.val;

--- a/tests/randomize-constraints/constraint_enum.sv
+++ b/tests/randomize-constraints/constraint_enum.sv
@@ -17,16 +17,20 @@ class Cls;
 endclass
 
 module top (
+    input clk,
     output int o
 );
     Cls obj;
     initial begin
        int success;
-       for (int i = 0; i < 5; i++) begin
+       for (int i = 0; i < 50; i++) begin
          obj= new;
          success = obj.randomize();
          $display("val = %0b", obj.val);
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 
     assign o = obj.val;

--- a/tests/randomize-constraints/constraint_foreach.sv
+++ b/tests/randomize-constraints/constraint_foreach.sv
@@ -11,14 +11,19 @@ class Cls;
   // Example end
 endclass
 
-module top ();
+module top (
+    input clk
+);
     Cls obj;
     initial begin
        int success;
        obj= new;
        success = obj.randomize();
-       for (int i = 0; i < 5; i++) begin
+       for (int i = 0; i < 50; i++) begin
          $display("A[%d] = %0d", i, obj.A[i]);
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 endmodule

--- a/tests/randomize-constraints/constraint_foreach_inside.sv
+++ b/tests/randomize-constraints/constraint_foreach_inside.sv
@@ -11,14 +11,21 @@ class Cls;
   // Example end
 endclass
 
-module top ();
+module top (
+    input clk
+);
     Cls obj;
     initial begin
-       int success;
-       obj= new;
-       success = obj.randomize();
-       for (int i = 0; i < 5; i++) begin
-         $display("A[%d] = %0d", i, obj.A[i]);
-       end
+        int success;
+        for (int i = 0; i < 50; i++) begin
+             obj= new;
+             success = obj.randomize();
+             for (int i = 0; i < 5; i++) begin
+                 $display("A[%d] = %0d", i, obj.A[i]);
+             end
+             assert (success == 1) else
+                 $error("Randomize failed with %d", success);
+        end
+        $finish;
     end
 endmodule

--- a/tests/randomize-constraints/constraint_if.sv
+++ b/tests/randomize-constraints/constraint_if.sv
@@ -22,16 +22,20 @@ class Cls;
 endclass
 
 module top (
+    input clk,
     output logic [7:0] o
 );
     Cls obj;
     initial begin
        int success;
-       for (int i = 0; i < 5; i++) begin
+       for (int i = 0; i < 50; i++) begin
          obj= new;
          success = obj.randomize();
          $display("val = %0b", obj.val);
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 
     assign o = obj.val;

--- a/tests/randomize-constraints/constraint_impl.sv
+++ b/tests/randomize-constraints/constraint_impl.sv
@@ -20,16 +20,20 @@ class Cls;
 endclass
 
 module top (
+    input clk,
     output logic [7:0] o
 );
     Cls obj;
     initial begin
        int success;
-       for (int i = 0; i < 5; i++) begin
+       for (int i = 0; i < 50; i++) begin
          obj= new;
          success = obj.randomize();
          $display("val = %0b", obj.val);
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 
     assign o = obj.val;

--- a/tests/randomize-constraints/constraint_range.sv
+++ b/tests/randomize-constraints/constraint_range.sv
@@ -16,16 +16,20 @@ class Cls;
 endclass
 
 module top (
+    input clk,
     output logic [7:0] o
 );
     Cls obj;
     initial begin
        int success;
-       for (int i = 0; i < 5; i++) begin
+       for (int i = 0; i < 50; i++) begin
          obj= new;
          success = obj.randomize();
          $display("val = %0b", obj.val);
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 
     assign o = obj.val;

--- a/tests/randomize-constraints/constraint_reduction.sv
+++ b/tests/randomize-constraints/constraint_reduction.sv
@@ -11,14 +11,21 @@ class Cls;
   // Example end
 endclass
 
-module top ();
+module top (
+    input clk
+);
     Cls obj;
     initial begin
        int success;
-       obj= new;
-       success = obj.randomize();
-       for (int i = 0; i < 5; i++) begin
-         $display("A[%d] = %0b", i, obj.A[i]);
+       for (int i = 0; i < 50; i++) begin
+         obj= new;
+         success = obj.randomize();
+         for (int i = 0; i < 5; i++) begin
+           $display("A[%d] = %0b", i, obj.A[i]);
+         end
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 endmodule

--- a/tests/randomize-constraints/constraint_set.sv
+++ b/tests/randomize-constraints/constraint_set.sv
@@ -16,16 +16,20 @@ class Cls;
 endclass
 
 module top (
+    input clk,
     output logic [7:0] o
 );
     Cls obj;
     initial begin
        int success;
-       for (int i = 0; i < 5; i++) begin
+       for (int i = 0; i < 50; i++) begin
          obj= new;
          success = obj.randomize();
          $display("val = %0b", obj.val);
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 
     assign o = obj.val;

--- a/tests/randomize-constraints/constraint_soft.sv
+++ b/tests/randomize-constraints/constraint_soft.sv
@@ -19,16 +19,20 @@ class Cls;
 endclass
 
 module top (
+    input clk,
     output logic [7:0] o
 );
     Cls obj;
     initial begin
        int success;
-       for (int i = 0; i < 5; i++) begin
+       for (int i = 0; i < 50; i++) begin
          obj= new;
          success = obj.randomize();
          $display("val = %0b", obj.val);
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 
     assign o = obj.val;

--- a/tests/randomize-constraints/constraint_solve.sv
+++ b/tests/randomize-constraints/constraint_solve.sv
@@ -20,16 +20,20 @@ class Cls;
 endclass
 
 module top (
+    input clk,
     output logic [7:0] o
 );
     Cls obj;
     initial begin
        int success;
-       for (int i = 0; i < 5; i++) begin
+       for (int i = 0; i < 50; i++) begin
          obj= new;
          success = obj.randomize();
          $display("val = %0b", obj.val);
+         assert (success == 1) else
+           $error("Randomize failed with %d", success);
        end
+       $finish;
     end
 
     assign o = obj.val;


### PR DESCRIPTION
Previously they were failing due to missing `input clk`. Also add checks for randomization success.