### PR TITLE
Add supply1_net test, fix tests with expected value z

### DIFF
--- a/tests/signal-strengths/highz0.sv
+++ b/tests/signal-strengths/highz0.sv
@@ -11,7 +11,7 @@ module top (
 );
 
    // Example:
-   assign (highz0, weak1) o = clk;
+   assign (highz0, weak1) o = 1;
    // Example end
 
    always begin

--- a/tests/signal-strengths/nor.sv
+++ b/tests/signal-strengths/nor.sv
@@ -1,7 +1,7 @@
 /* *** Issue description
 
    Verilator does not support signal strength specifiers.
-   This test tests replacing 0 with z by highz0 strength in nor gate.
+   This test tests replacing 1 with z by highz1 strength in nor gate.
 
    *** End of description
 */
@@ -11,7 +11,7 @@ module top (
 );
 
     // Example from 28.3.2:
-   nor (highz1, strong0) n1(o, clk, 0);
+   nor (highz1, strong0) n1(o, 0, 0);
     // Example end
    always begin
       if (o === 1'z)

--- a/tests/signal-strengths/supply1_net.sv
+++ b/tests/signal-strengths/supply1_net.sv
@@ -1,0 +1,21 @@
+/* *** Issue description
+
+   Verilator does not support signal strength specifiers.
+   This test tests parsing of supply1 net.
+
+   *** End of description
+*/
+module top (
+    input wire clk,
+    output wire o
+);
+
+    // Example:
+        supply1 supply1_net;
+    // Example end
+   assign o = supply1_net;
+   always begin
+      if (o)
+        $finish;
+   end
+endmodule


### PR DESCRIPTION
Tests that expect value `z` assigned to output port were passed, even if the functionality weren't implemented yet.

I found in 6.7.1 that: `The default initialization value for a net shall be the value z`. I think these tests were passed, because input port has value `z` at the very beginning of simulation.
The problem doesn't occur after this change.