### PR TITLE
Remove separate V5 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,3 @@
 	path = verilator/virtual-interfaces
 	url = ../verilator-1
 	branch = virtual-interfaces
-[submodule "verilator/develop-v5"]
-	path = verilator/develop-v5
-	url = ../../verilator/verilator
-	branch = develop-v5

--- a/branches.yml
+++ b/branches.yml
@@ -1,8 +1,5 @@
 master:
   - default
-develop-v5:
-  - asserts
-  - event-control-expression
 randomize-constraints:
   - randomize-constraints
 virtual-interfaces:


### PR DESCRIPTION
V5 has been merged into `master`, so no need to test against `develop-v5` anymore.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>