### PR TITLE
Add missing asserts test

### DIFF
--- a/tests/asserts/assert_sampled.sv
+++ b/tests/asserts/assert_sampled.sv
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t(input logic clk);
+    int cyc = 0;
+    logic val = 0;
+
+    // No assert in this test, but every variable X in an assert is $sampled(X)
+    always @(posedge clk) begin
+        cyc <= cyc + 1;
+
+        if (val != $sampled(val))
+            $stop;
+
+        val = ~val;
+
+        if (val == $sampled(val))
+            $stop;
+
+        $display("t=%0t   cyc=%0d   val=%b", $time, cyc, val);
+        if (cyc > 10) $finish;
+    end
+endmodule


### PR DESCRIPTION
Functions `$rose`, `$fell`, `$changed` etc. all depend on support for `$past`, but `$past` itself depends on `$sampled`.

Sampling used to be unsupported in Verilator until recently, and we lack a test of it.

The test doesn't explicitly use concurrent assertions, because all variables inside asserts are sampled by default.
