### PR TITLE
Fix false negative tests

### DIFF
--- a/tests/class-params/class_parameter_type_alias.sv
+++ b/tests/class-params/class_parameter_type_alias.sv
@@ -17,7 +17,7 @@ module top (
     output logic [7:0] o
 );
     SelfRefClassTypeParam src_logic;
-    SelfRefClassTypeParam::self_int_t src_int;
+    SelfRefClassTypeParam#(logic)::self_int_t src_int;
     initial begin
         src_int = new;
         src_logic = new;

--- a/tests/class-params/class_value_parameter_type_alias.sv
+++ b/tests/class-params/class_value_parameter_type_alias.sv
@@ -16,7 +16,7 @@ module top (
     output logic [7:0] o
 );
     SelfRefClassIntParam src1;
-    SelfRefClassIntParam::self_int_t src10;
+    SelfRefClassIntParam#(1)::self_int_t src10;
     initial begin
         src1 = new;
         src10 = new;

--- a/tests/class/class_static_method.sv
+++ b/tests/class/class_static_method.sv
@@ -4,8 +4,8 @@
 */
 
 class Cls;
-   function static int get_cnt;
-      int cnt = 0;
+   static function int get_cnt;
+      static int cnt = 0;
       cnt++;
       return cnt;
    endfunction

--- a/tests/virtual-interfaces/class_virtual_interface.sv
+++ b/tests/virtual-interfaces/class_virtual_interface.sv
@@ -19,6 +19,10 @@ module top (
     input clk
 );
     Hold h;
-    intf i;
-    initial $finish;
+    intf i();
+    initial begin
+        h = new;
+        h.signals = i;
+        $finish;
+    end
 endmodule

--- a/tests/virtual-interfaces/virtual_interface.sv
+++ b/tests/virtual-interfaces/virtual_interface.sv
@@ -13,6 +13,10 @@ module top (
 );
     virtual interface intf signals;
     virtual intf signals2;
-    intf i;
-    initial $finish;
+    intf i();
+    initial begin
+        signals = i;
+        signals2 = signals;
+        $finish;
+    end
 endmodule


### PR DESCRIPTION
Some tests are malformed, which causes them to fail, even if the features they test are supported. This PR addresses that.