### PR TITLE
Update logs

### DIFF
--- a/tests/uvm-tests/expected_outputs/complex_uvm_agent_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/complex_uvm_agent_expected_output.txt
@@ -26,5 +26,27 @@ UVM_INFO @ 0: reporter [RNTST] Running test ...
 UVM_INFO tests/uvm-tests/uvm_test.sv(21) @ 0: reporter [RESULT] build phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(26) @ 0: reporter [RESULT] connect phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(31) @ 0: reporter [RESULT] end of elaboration phase completed
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "C" of the component "C" violates the uvm component name constraints
 UVM_INFO tests/uvm-tests/uvm_test.sv(36) @ 0: reporter [RESULT] start of simulation phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(40) @ 0: reporter [RESULT] run phase phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(45) @ 0: reporter [RESULT] extract phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(50) @ 0: reporter [RESULT] check phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(55) @ 0: reporter [RESULT] report phase completed
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :   12
+UVM_WARNING :    8
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[RESULT]     9
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]     1
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish

--- a/tests/uvm-tests/expected_outputs/complex_uvm_component_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/complex_uvm_component_expected_output.txt
@@ -26,5 +26,27 @@ UVM_INFO @ 0: reporter [RNTST] Running test ...
 UVM_INFO tests/uvm-tests/uvm_test.sv(21) @ 0: reporter [RESULT] build phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(26) @ 0: reporter [RESULT] connect phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(31) @ 0: reporter [RESULT] end of elaboration phase completed
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "C" of the component "C" violates the uvm component name constraints
 UVM_INFO tests/uvm-tests/uvm_test.sv(36) @ 0: reporter [RESULT] start of simulation phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(40) @ 0: reporter [RESULT] run phase phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(45) @ 0: reporter [RESULT] extract phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(50) @ 0: reporter [RESULT] check phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(55) @ 0: reporter [RESULT] report phase completed
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :   12
+UVM_WARNING :    8
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[RESULT]     9
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]     1
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish

--- a/tests/uvm-tests/expected_outputs/complex_uvm_driver_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/complex_uvm_driver_expected_output.txt
@@ -27,5 +27,30 @@ UVM_INFO tests/uvm-tests/uvm_test.sv(21) @ 0: reporter [RESULT] build phase comp
 UVM_INFO tests/uvm-tests/uvm_test.sv(26) @ 0: reporter [RESULT] connect phase completed
 UVM_WARNING uvm/src/comps/uvm_driver.svh(90) @ 0: C [DRVCONNECT] the driver is not connected to a sequencer via the standard mechanisms enabled by connect()
 UVM_INFO tests/uvm-tests/uvm_test.sv(31) @ 0: reporter [RESULT] end of elaboration phase completed
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "C" of the component "C" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "rsp_port" of the component "C.rsp_port" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "seq_item_port" of the component "C.seq_item_port" violates the uvm component name constraints
 UVM_INFO tests/uvm-tests/uvm_test.sv(36) @ 0: reporter [RESULT] start of simulation phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(40) @ 0: reporter [RESULT] run phase phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(45) @ 0: reporter [RESULT] extract phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(50) @ 0: reporter [RESULT] check phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(55) @ 0: reporter [RESULT] report phase completed
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :   12
+UVM_WARNING :   11
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[DRVCONNECT]     1
+[RESULT]     9
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]     3
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish

--- a/tests/uvm-tests/expected_outputs/complex_uvm_env_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/complex_uvm_env_expected_output.txt
@@ -26,5 +26,27 @@ UVM_INFO @ 0: reporter [RNTST] Running test ...
 UVM_INFO tests/uvm-tests/uvm_test.sv(21) @ 0: reporter [RESULT] build phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(26) @ 0: reporter [RESULT] connect phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(31) @ 0: reporter [RESULT] end of elaboration phase completed
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "C" of the component "C" violates the uvm component name constraints
 UVM_INFO tests/uvm-tests/uvm_test.sv(36) @ 0: reporter [RESULT] start of simulation phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(40) @ 0: reporter [RESULT] run phase phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(45) @ 0: reporter [RESULT] extract phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(50) @ 0: reporter [RESULT] check phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(55) @ 0: reporter [RESULT] report phase completed
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :   12
+UVM_WARNING :    8
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[RESULT]     9
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]     1
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish

--- a/tests/uvm-tests/expected_outputs/complex_uvm_monitor_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/complex_uvm_monitor_expected_output.txt
@@ -26,5 +26,27 @@ UVM_INFO @ 0: reporter [RNTST] Running test ...
 UVM_INFO tests/uvm-tests/uvm_test.sv(21) @ 0: reporter [RESULT] build phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(26) @ 0: reporter [RESULT] connect phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(31) @ 0: reporter [RESULT] end of elaboration phase completed
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "C" of the component "C" violates the uvm component name constraints
 UVM_INFO tests/uvm-tests/uvm_test.sv(36) @ 0: reporter [RESULT] start of simulation phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(40) @ 0: reporter [RESULT] run phase phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(45) @ 0: reporter [RESULT] extract phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(50) @ 0: reporter [RESULT] check phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(55) @ 0: reporter [RESULT] report phase completed
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :   12
+UVM_WARNING :    8
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[RESULT]     9
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]     1
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish

--- a/tests/uvm-tests/expected_outputs/complex_uvm_scoreboard_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/complex_uvm_scoreboard_expected_output.txt
@@ -26,5 +26,27 @@ UVM_INFO @ 0: reporter [RNTST] Running test ...
 UVM_INFO tests/uvm-tests/uvm_test.sv(21) @ 0: reporter [RESULT] build phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(26) @ 0: reporter [RESULT] connect phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(31) @ 0: reporter [RESULT] end of elaboration phase completed
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "C" of the component "C" violates the uvm component name constraints
 UVM_INFO tests/uvm-tests/uvm_test.sv(36) @ 0: reporter [RESULT] start of simulation phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(40) @ 0: reporter [RESULT] run phase phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(45) @ 0: reporter [RESULT] extract phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(50) @ 0: reporter [RESULT] check phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(55) @ 0: reporter [RESULT] report phase completed
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :   12
+UVM_WARNING :    8
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[RESULT]     9
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]     1
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish

--- a/tests/uvm-tests/expected_outputs/complex_uvm_sequencer_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/complex_uvm_sequencer_expected_output.txt
@@ -26,5 +26,40 @@ UVM_INFO @ 0: reporter [RNTST] Running test ...
 UVM_INFO tests/uvm-tests/uvm_test.sv(21) @ 0: reporter [RESULT] build phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(26) @ 0: reporter [RESULT] connect phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(31) @ 0: reporter [RESULT] end of elaboration phase completed
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "C" of the component "C" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "req_fifo" of the component "C.req_fifo" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "get_ap" of the component "C.req_fifo.get_ap" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "get_peek_export" of the component "C.req_fifo.get_peek_export" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "put_ap" of the component "C.req_fifo.put_ap" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "put_export" of the component "C.req_fifo.put_export" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "rsp_export" of the component "C.rsp_export" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "seq_item_export" of the component "C.seq_item_export" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "sqr_rsp_analysis_fifo" of the component "C.sqr_rsp_analysis_fifo" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "analysis_export" of the component "C.sqr_rsp_analysis_fifo.analysis_export" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "get_ap" of the component "C.sqr_rsp_analysis_fifo.get_ap" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "get_peek_export" of the component "C.sqr_rsp_analysis_fifo.get_peek_export" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "put_ap" of the component "C.sqr_rsp_analysis_fifo.put_ap" violates the uvm component name constraints
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "put_export" of the component "C.sqr_rsp_analysis_fifo.put_export" violates the uvm component name constraints
 UVM_INFO tests/uvm-tests/uvm_test.sv(36) @ 0: reporter [RESULT] start of simulation phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(40) @ 0: reporter [RESULT] run phase phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(45) @ 0: reporter [RESULT] extract phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(50) @ 0: reporter [RESULT] check phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(55) @ 0: reporter [RESULT] report phase completed
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :   12
+UVM_WARNING :   21
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[RESULT]     9
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]    14
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish

--- a/tests/uvm-tests/expected_outputs/complex_uvm_test_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/complex_uvm_test_expected_output.txt
@@ -26,5 +26,27 @@ UVM_INFO @ 0: reporter [RNTST] Running test ...
 UVM_INFO tests/uvm-tests/uvm_test.sv(21) @ 0: reporter [RESULT] build phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(26) @ 0: reporter [RESULT] connect phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(31) @ 0: reporter [RESULT] end of elaboration phase completed
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "C" of the component "C" violates the uvm component name constraints
 UVM_INFO tests/uvm-tests/uvm_test.sv(36) @ 0: reporter [RESULT] start of simulation phase completed
 UVM_INFO tests/uvm-tests/uvm_test.sv(40) @ 0: reporter [RESULT] run phase phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(45) @ 0: reporter [RESULT] extract phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(50) @ 0: reporter [RESULT] check phase completed
+UVM_INFO tests/uvm-tests/uvm_test.sv(55) @ 0: reporter [RESULT] report phase completed
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :   12
+UVM_WARNING :    8
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[RESULT]     9
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]     1
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish

--- a/tests/uvm-tests/expected_outputs/uvm_resource_db_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/uvm_resource_db_expected_output.txt
@@ -23,3 +23,22 @@ All Rights Reserved Worldwide
 
 UVM_INFO @ 0: reporter [RNTST] Running test ...
 UVM_INFO tests/uvm-tests/uvm_test.sv(79) @ 0: ReadByName [RESULT] read_by_name successful
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "ReadByName" of the component "ReadByName" violates the uvm component name constraints
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :    4
+UVM_WARNING :    8
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[RESULT]     1
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]     1
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish

--- a/tests/uvm-tests/expected_outputs/uvm_test_run_test_expected_output.txt
+++ b/tests/uvm-tests/expected_outputs/uvm_test_run_test_expected_output.txt
@@ -22,4 +22,23 @@ All Rights Reserved Worldwide
       (Specify +UVM_NO_RELNOTES to turn off this notice)
 
 UVM_INFO @ 0: reporter [RNTST] Running test MyUvmTest...
+UVM_INFO uvm/src/base/uvm_traversal.svh(289) @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
+UVM_WARNING uvm/src/base/uvm_traversal.svh(274) @ 0: reporter [UVM/COMP/NAME] the name "uvm_test_top" of the component "uvm_test_top" violates the uvm component name constraints
 UVM_INFO tests/uvm-tests/uvm_test.sv(144) @ 0: uvm_test_top [RESULT] SUCCESS, MyUvmTest called
+UVM_INFO uvm/src/base/uvm_report_server.svh(864) @ 0: reporter [UVM/REPORT/SERVER] 
+--- UVM Report Summary ---
+
+** Report counts by severity
+UVM_INFO :    4
+UVM_WARNING :    8
+UVM_ERROR :    0
+UVM_FATAL :    0
+** Report counts by id
+[RESULT]     1
+[RNTST]     1
+[TPRGED]     7
+[UVM/COMP/NAME]     1
+[UVM/COMP/NAMECHECK]     1
+[UVM/RELNOTES]     1
+
+- uvm/src/base/uvm_root.svh:585: Verilog $finish


### PR DESCRIPTION
The logs required an update, because we dropped 3 patches. Another reason is that previous logs were gathered without `UVM_NO_DPI` define.