### PR TITLE
Add test timeout

### DIFF
--- a/templates/suite.robot
+++ b/templates/suite.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Library           Process
 Suite Teardown    Terminate All Processes    kill=True
+Test Timeout      5 minutes
 
 *** Test Cases ***
 {{ test_cases }}


### PR DESCRIPTION
This should allow us to bump Verilator even if there are some regressions that cause tests to get stuck.