### PR TITLE
Replace VL_WRITEF with VL_PRINTF

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char *argv[]) {
         top->clk = 1 & ~top->clk;
         top->contextp()->timeInc(1);
         if (top->contextp()->time() > MAX_TIME) {
-            VL_WRITEF("Test timed out!");
+            VL_PRINTF("Test timed out!");
             return -15;
         }
     }


### PR DESCRIPTION
Each test that should pass failed, because `VL_WRITEF` command seems to be removed. I replaced it with `VL_PRINTF` and it works.