### PR TITLE
Remove the line with the warning about stack size from the output

### DIFF
--- a/scripts/test_uvm
+++ b/scripts/test_uvm
@@ -24,4 +24,5 @@ mkdir -p $REPO_DIR/out/$SUITE/$TEST
 
 verilator --binary $UVM_DIR/uvm.sv -I$UVM_DIR $SUITE_DIR/uvm_test.sv -Mdir $OUT_DIR --timing -DUVM_NO_DPI -Wno-lint -Wno-style -Wno-CONSTRAINTIGN -Wno-ZERODLY -Wno-SYMRSVDWORD --build-jobs `nproc` --prefix Vtop $@
 timeout 100 $OUT_DIR/Vtop +$TEST | tee ${TEST}_output.txt
+sed -i '/%Warning: System has stack size/d' ${TEST}_output.txt
 diff ${TEST}_output.txt $SUITE_DIR/expected_outputs/${TEST}_expected_output.txt


### PR DESCRIPTION
Verilator adds such a warning, which causes fails, because the diff is not empty. An example whole message is
```
%Warning: System has stack size 8192 kb which may be too small; suggest 'ulimit -s 25193' or larger
```
I think it's best to exclude it from comparing, especially that the suggested size may differ in various verilator versions.