### PR TITLE
Extend test timeout

### DIFF
--- a/templates/asserts.robot
+++ b/templates/asserts.robot
@@ -1,6 +1,6 @@
 {{ test }}
     [Tags]     {{ tags }}
-    ${result} =    Run Process    scripts/test    {{ suite }}    {{ test }}    {{ verilator_root }}    --assert    timeout={{ timeout }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
+    ${result} =    Run Process    scripts/test    {{ suite }}    {{ test }}    {{ verilator_root }}    --assert    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
     Log    ${result.stdout}
     Run Keyword If    ${result.rc}==-15    Set Tags    Timeout
     Should Be Equal As Integers    ${result.rc}    0

--- a/templates/default.robot
+++ b/templates/default.robot
@@ -1,6 +1,6 @@
 {{ test }}
     [Tags]     {{ tags }}
-    ${result} =    Run Process    scripts/test    {{ suite }}    {{ test }}    {{ verilator_root }}    timeout={{ timeout }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
+    ${result} =    Run Process    scripts/test    {{ suite }}    {{ test }}    {{ verilator_root }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
     Log    ${result.stdout}
     Run Keyword If    ${result.rc}==-15    Set Tags    Timeout
     Should Be Equal As Integers    ${result.rc}    0

--- a/templates/event-control-expression.robot
+++ b/templates/event-control-expression.robot
@@ -1,6 +1,6 @@
 {{ test }}
     [Tags]     {{ tags }}
-    ${result} =    Run Process  scripts/test  {{ suite }}  {{ test }}  {{ verilator_root }}  --timing    timeout={{ timeout }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
+    ${result} =    Run Process  scripts/test  {{ suite }}  {{ test }}  {{ verilator_root }}  --timing    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
     Log    ${result.stdout}
     Run Keyword If    ${result.rc}==-15    Set Tags    Timeout
     Should Be Equal As Integers    ${result.rc}    0

--- a/templates/signal-strengths-should-fail.robot
+++ b/templates/signal-strengths-should-fail.robot
@@ -1,5 +1,5 @@
 {{ test }}
     [Tags]     {{ tags }}
-    ${result} =    Run Process    scripts/test    {{ suite }}    {{ test }}    {{ verilator_root }}    timeout={{ timeout }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
+    ${result} =    Run Process    scripts/test    {{ suite }}    {{ test }}    {{ verilator_root }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
     Log    ${result.stdout}
     Should Not Be Equal As Integers    ${result.rc}    0

--- a/templates/suite.robot
+++ b/templates/suite.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Library           Process
 Suite Teardown    Terminate All Processes    kill=True
-Test Timeout      5 minutes
+Test Timeout      30 minutes
 
 *** Test Cases ***
 {{ test_cases }}

--- a/templates/uvm-testbenches.robot
+++ b/templates/uvm-testbenches.robot
@@ -1,7 +1,7 @@
 {{ test }}
     [Tags]     {{ tags }}
     Run Process    make    -C    tests/{{ suite }}/{{ test }}    clean
-    ${result} =    Run Process    make    -C    tests/{{ suite }}/{{ test }}    env:UVM_ROOT=%{PWD}/uvm    env:VERILATOR_ROOT=%{PWD}/{{ verilator_root }}    timeout={{ timeout }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
+    ${result} =    Run Process    make    -C    tests/{{ suite }}/{{ test }}    env:UVM_ROOT=%{PWD}/uvm    env:VERILATOR_ROOT=%{PWD}/{{ verilator_root }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
     Log    ${result.stdout}
     Run Keyword If    ${result.rc}==-15    Set Tags    Timeout
     Should Be Equal As Integers    ${result.rc}    0

--- a/templates/uvm-tests.robot
+++ b/templates/uvm-tests.robot
@@ -1,6 +1,6 @@
 {{ test }}
     [Tags]     {{ tags }}
-    ${result} =    Run Process    scripts/test_uvm    {{ suite }}    {{ test }}    {{ verilator_root }}    timeout={{ timeout }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
+    ${result} =    Run Process    scripts/test_uvm    {{ suite }}    {{ test }}    {{ verilator_root }}    stdout=out/{{ suite }}/{{ test }}/stdout.log    stderr=STDOUT
     Log    ${result.stdout}
     Run Keyword If    ${result.rc}==-15    Set Tags    Timeout
     Should Be Equal As Integers    ${result.rc}    0


### PR DESCRIPTION
The current timeout seems to short for UVM tests which may be the reason for some of the failures.