### PR TITLE
Don't print simulation stats

### DIFF
--- a/scripts/test_uvm
+++ b/scripts/test_uvm
@@ -23,6 +23,6 @@ mkdir -p $OUT_DIR
 mkdir -p $REPO_DIR/out/$SUITE/$TEST
 
 verilator --binary $UVM_DIR/uvm.sv -I$UVM_DIR $SUITE_DIR/uvm_test.sv -Mdir $OUT_DIR --timing -DUVM_NO_DPI -Wno-lint -Wno-style -Wno-CONSTRAINTIGN -Wno-ZERODLY -Wno-SYMRSVDWORD --build-jobs `nproc` --prefix Vtop $@
-timeout 100 $OUT_DIR/Vtop +$TEST | tee ${TEST}_output.txt
+timeout 100 $OUT_DIR/Vtop +$TEST +verilator+quiet | tee ${TEST}_output.txt
 sed -i '/%Warning: System has stack size/d' ${TEST}_output.txt
 diff ${TEST}_output.txt $SUITE_DIR/expected_outputs/${TEST}_expected_output.txt


### PR DESCRIPTION
Some test fail, because output comparison fails due to simulation statistics. This PR disables printing them.