### PR TITLE
Remove `randomize-constraints` branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,6 @@
 [submodule "verilator/master"]
 	path = verilator/master
 	url = https://github.com/verilator/verilator
-[submodule "verilator/randomize-constraints"]
-	path = verilator/randomize-constraints
-	url = https://github.com/antmicro/verilator-1
-	branch = randomize-constraints-crave
 [submodule "uvm"]
 	path = uvm
 	url = https://github.com/antmicro/uvm-verilator.git

--- a/README.md
+++ b/README.md
@@ -95,16 +95,16 @@ robot *.robot
 
 All tests are divided into several test suites. The file `branches.yml` defines
 which suite is tested with which branch of Verilator. To generate tests for a
-specific branch of Verilator (e.g., `randomize-constraints`):
+specific branch of Verilator (let's call it `foo`):
 
 ```
-./gen-tests randomize-constraints
+./gen-tests foo
 ```
 
 Multiple branches can be passed:
 
 ```
-./gen-tests master randomize-constraints
+./gen-tests master foo
 ```
 
 Robot tests are generated from Jinja2 templates in the `templates` directory.

--- a/branches.yml
+++ b/branches.yml
@@ -2,5 +2,3 @@ master:
   - default
 axi-vip:
   - uvm-testbenches
-randomize-constraints:
-  - randomize-constraints


### PR DESCRIPTION
It is outdated and superseded by what we contributed to the upstream.