### PR TITLE
Fix ignored newlines in logs

### DIFF
--- a/theme/rebot/log.css
+++ b/theme/rebot/log.css
@@ -608,7 +608,7 @@ input[type=radio]:checked{
 .messages .message{
     line-height:1.375em;
     padding:0 16px;
-    word-break:break-all
+    white-space:pre-wrap;
 }
 .message-row:hover .select-message div{
     background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAABmJLR0QA/wD/AP+gvaeTAAAAkElEQVQoke2RsQkCQRBF3+yusiCoYHhoMzZjAWaXbBdajUXYgWBg4B1qtMk4JmKgK5wmJv7ww5v58ASA1M7ABYqRE2nUPreBupmitgMtc7AB5q9gjzNqaxBXxMy27y5+FWF5GBD7K8RiJ8IkE/JCqI8VTvYfvfPXSgBIzZDsfScoqpIml7sCGRP563gs+JWOG/6FQAtiIqzeAAAAAElFTkSuQmCC") center no-repeat;


### PR DESCRIPTION
Previous css ignored newlines in log output resulting in unreadable blob of text:
![Screenshot from 2024-09-10 15-59-35](https://github.com/user-attachments/assets/59dae54e-782d-4803-9cf2-c1f67fb4c628)


Now original formatting is perserved:
![image](https://github.com/user-attachments/assets/a3d3d9e2-12b8-4f75-b4ac-273fe74b562e)
