### PR TITLE
Drop the `axi-vip` branch of Verilator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,3 @@
 	path = tests/uvm-testbenches/axi-vip/axi-vip
 	url = https://github.com/antmicro/axi-vip
 	branch = verilator
-[submodule "verilator/uvm"]
-	path = verilator/axi-vip
-	url = https://github.com/antmicro/verilator
-	branch = basic-dist-honoring

--- a/branches.yml
+++ b/branches.yml
@@ -1,4 +1,2 @@
 master:
   - default
-axi-vip:
-  - uvm-testbenches


### PR DESCRIPTION
It is not needed for building `axi-vip`.