### PR TITLE
Fix typo'd comments in mem-tb

### DIFF
--- a/tests/uvm-testbenches/mem-tb/hdl/mem_base_test.sv
+++ b/tests/uvm-testbenches/mem-tb/hdl/mem_base_test.sv
@@ -38,7 +38,7 @@ class mem_model_base_test extends uvm_test;
   endfunction
 
   //---------------------------------------
-  // end_of_elobaration phase
+  // report_phase
   //---------------------------------------
  function void report_phase(uvm_phase phase);
    uvm_report_server svr;

--- a/tests/uvm-testbenches/mem-tb/hdl/mem_base_test.sv
+++ b/tests/uvm-testbenches/mem-tb/hdl/mem_base_test.sv
@@ -30,7 +30,7 @@ class mem_model_base_test extends uvm_test;
   endfunction : build_phase
 
   //---------------------------------------
-  // end_of_elobaration phase
+  // end_of_elaboration phase
   //---------------------------------------
   virtual function void end_of_elaboration();
     //print's the topology


### PR DESCRIPTION
This is a tiny (but easy) fix to a couple of comments documenting phases in the base test of `mem-tb`. No code changes.