### PR TITLE
Remove -Wno-CONSTRAINTIGN flag

### DIFF
--- a/scripts/test_uvm
+++ b/scripts/test_uvm
@@ -22,7 +22,7 @@ OUT_DIR=$REPO_DIR/out/$SUITE/uvm
 mkdir -p $OUT_DIR
 mkdir -p $REPO_DIR/out/$SUITE/$TEST
 
-verilator --binary $UVM_DIR/uvm.sv -I$UVM_DIR $SUITE_DIR/uvm_test.sv -Mdir $OUT_DIR --timing -DUVM_NO_DPI -Wno-lint -Wno-style -Wno-CONSTRAINTIGN -Wno-ZERODLY -Wno-SYMRSVDWORD --build-jobs `nproc` --prefix Vtop $@
+verilator --binary $UVM_DIR/uvm.sv -I$UVM_DIR $SUITE_DIR/uvm_test.sv -Mdir $OUT_DIR --timing -DUVM_NO_DPI -Wno-lint -Wno-style -Wno-ZERODLY -Wno-SYMRSVDWORD --build-jobs `nproc` --prefix Vtop $@
 timeout 100 $OUT_DIR/Vtop +$TEST +verilator+quiet | tee ${TEST}_output.txt
 sed -i '/%Warning: System has stack size/d' ${TEST}_output.txt
 diff ${TEST}_output.txt $SUITE_DIR/expected_outputs/${TEST}_expected_output.txt

--- a/tests/uvm-testbenches/mem-tb/Makefile
+++ b/tests/uvm-testbenches/mem-tb/Makefile
@@ -30,7 +30,6 @@ WARNING_ARGS += -Wno-lint \
 	-Wno-style \
 	-Wno-SYMRSVDWORD \
 	-Wno-IGNOREDRETURN \
-	-Wno-CONSTRAINTIGN \
 	-Wno-ZERODLY
 
 # -------------------------------------


### PR DESCRIPTION
With the newest Verilator all constraints present in UVM are supported. This PR removes the flag that disables warning regarding unsupported constraints. It also bumps UVM, because patch that removes constraints is no longer needed.