### PR TITLE
Fix memory initialization in mem-tb

### DIFF
--- a/tests/uvm-testbenches/mem-tb/hdl/tbench_top.sv
+++ b/tests/uvm-testbenches/mem-tb/hdl/tbench_top.sv
@@ -29,7 +29,7 @@ module tbench_top;
   //reset Generation
   //---------------------------------------
   initial begin
-    reset = 1;
+    #1 reset = 1;
     #5 reset =0;
   end
 


### PR DESCRIPTION
Mem-tb testbench currently doesn't work, because the memory isn't initialized with `FF` values as expected in the test. The initialization is done on `posedge(reset`:
https://github.com/antmicro/verilator-verification-features-tests/blob/3c4beb09d6277c9a6bfffc2ad94caaa3036e568e/tests/uvm-testbenches/mem-tb/hdl/design.sv#L39
which isn't triggered by the variable initialization. It works when the delay is added.

The testbench stooped working after https://github.com/verilator/verilator/commit/0aa8356ecad840d7e1cd82ff9c41e2e9c6b99efb. With that commit, the output of `%m` has changed: https://github.com/antmicro/uvm-verilator/blob/795b5f263c5d440c26e6d3598b406d44dd23fbd9/src/base/uvm_misc.svh#L110
which is then used in computation of random seed, which should always be the same.
`%m` changed, so did the seed and the values that were obtained by randomization. We entered into the case in which we read the memory cell which wasn't written and the tests started failing. It seems that this case wasn't tested before.