### PR TITLE
Pin Ubuntu to 22.04 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   matrix:
     name: Generate test matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.make_matrix.outputs.matrix }}
     steps:
@@ -29,7 +29,7 @@ jobs:
   test:
     name: Test branch ${{ matrix.VERILATOR_BRANCH }}
     needs: matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -93,7 +93,7 @@ jobs:
     name: Automerge dependabot pull requests
     needs: [test]
     if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
@@ -103,7 +103,7 @@ jobs:
   report:
     name: Generate test report
     needs: [test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout


### PR DESCRIPTION
The `report` CI step [depends on Python 3.10](https://github.com/antmicro/verilator-verification-features-tests/blob/84b923ac1297f799a2a7be6098c37549a3df7d87/.github/workflows/test.yml#L120). The recent update of `ubuntu-latest` to 24.04 breaks it. This patch pins the Ubuntu version to 22.04 for all jobs to avoid such issues. Long term, we should probably avoid depending on version-specific paths.